### PR TITLE
Remove distinct() from LeaveAdmin class - get_queryset() method

### DIFF
--- a/ninetofiver/admin.py
+++ b/ninetofiver/admin.py
@@ -233,8 +233,7 @@ class LeaveAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         return (super().get_queryset(request)
                 .select_related('leave_type', 'user')
-                .prefetch_related('attachments')
-                .distinct())
+                .prefetch_related('attachments'))
 
     def get_formsets_with_inlines(self, request, obj=None):
         """Cache timesheets foreign-keys in inlines"""


### PR DESCRIPTION
Deleting leaves gives Server Error (500).
In admin interface, when deleting single or multiple leaves, there was `TypeError: Cannot call delete() after .distinct().`
But the query is not generating duplicates, and obtained records should be unique every time.
So no reason for calling `distinct()` at the end of the query. 
Thus I removed this `distinct()` method call.