### PR TITLE
fix: add link to separate months in project contract overview refs #59352

### DIFF
--- a/ninetofiver/templates/ninetofiver/admin/reports/project_data.pug
+++ b/ninetofiver/templates/ninetofiver/admin/reports/project_data.pug
@@ -1,4 +1,6 @@
 - load format_duration
+- load split
+- load startswith
 
 div(class='row')
     div(class='col-4')
@@ -74,7 +76,14 @@ div(class='row')
             tbody
                 for month_data in record.months
                     tr
-                        td {{ month_data.month }}
+                        {% with month_data.month|split:"-" as date %}
+                        td
+                            {% if date.1|startswith:"0" %}
+                            a(href="{% url 'admin_report_timesheet_contract_overview' %}?year={{ date.0 }}&month={{ date.1|slice:'1:' }}") {{ date.0 }}-{{ date.1 }}
+                            {% else %}
+                            a(href="{% url 'admin_report_timesheet_contract_overview' %}?year={{ date.0 }}&month={{ date.1 }}") {{ date.0 }}-{{ date.1 }}
+                            {% endif %}
+                        {% endwith %}
                         td(class='text-nowrap') {{ month_data.performed_hours | format_duration }}
                         td
                             - include 'ninetofiver/admin/reports/progress_bar.html' with value=month_data.performed_pct

--- a/ninetofiver/templatetags/split.py
+++ b/ninetofiver/templatetags/split.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def split(value,arg:str):
+    """Splits a string using the given argument"""
+    if not value or not arg:
+        return value
+
+    return value.split(arg)

--- a/ninetofiver/templatetags/startswith.py
+++ b/ninetofiver/templatetags/startswith.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def startswith(value,arg:str):
+    """Checks if value starts with arg"""
+    if not value or not arg:
+        return value
+
+    return value.startswith(arg)


### PR DESCRIPTION
Each month in project contract overview is now a clickable link which redirects to timesheet contract overview filtered for that month