### PR TITLE
Fix auth api issue  - #131967

### DIFF
--- a/ninetofiver/authentication.py
+++ b/ninetofiver/authentication.py
@@ -10,29 +10,29 @@ class ApiKeyAuthentication(BaseTokenAuthentication):
 
     model = models.ApiKey
 
-    def authenticate(self, request):
-        """Authenticate the request."""
-        token = request.GET.get('api_key', None)
+    def authenticate(self, request): 
+        
+        # removed the following to prevent the use of query parameters for api_key
+        # token = request.GET.get('api_key', None) 
 
-        if not token:
-            auth = get_authorization_header(request).split()
+        """Authenticate the request.""" 
+        auth = get_authorization_header(request).split()
 
-            if auth and auth[0].lower() == self.keyword.lower().encode():
-                if len(auth) == 1:
-                    msg = _('Invalid token header. No credentials provided.')
-                    raise exceptions.AuthenticationFailed(msg)
-                elif len(auth) > 2:
-                    msg = _('Invalid token header. Token string should not contain spaces.')
-                    raise exceptions.AuthenticationFailed(msg)
+        if not auth or auth[0].lower() != self.keyword.lower().encode():
+            msg = _('Invalid token header. No credentials provided.')
+            raise exceptions.AuthenticationFailed(msg)
 
-                try:
-                    token = auth[1].decode()
-                except UnicodeError:
-                    msg = _('Invalid token header. Token string should not contain invalid characters.')
-                    raise exceptions.AuthenticationFailed(msg)
+        if len(auth) == 1:
+            msg = _('Invalid token header. No credentials provided.')
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = _('Invalid token header. Token string should not contain spaces.')
+            raise exceptions.AuthenticationFailed(msg)
 
-        if not token:
-            msg = _('Invalid token. No credentials provided.')
+        try:
+            token = auth[1].decode()
+        except UnicodeError:
+            msg = _('Invalid token header. Token string should not contain invalid characters.')
             raise exceptions.AuthenticationFailed(msg)
 
         res = self.authenticate_credentials(token)


### PR DESCRIPTION
Issue: api-keys can get passed through get requests, which is risky. It defaults to the authorization header anyways if not present (and YaYata doesn't send it out through the url anyways it seems) so not urgent, but better to remove it in my opinion.

This is inherited from the "Experimental read-only API key authentication" commit. Which didn't include the default to auth header if key not present in url. 
https://github.com/inuits/925r/commit/d484c9f09e37d5c8885d331bf60c770318cd2ec9

Proposed solution: remove the possibility to send keys through the url, even if it's not used -- better to completely remove the possibility. 
